### PR TITLE
docs: remove v3 tag from install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@ Displays the results of a GROQ query in a View Pane. With the ability to use fie
 ## Installation
 
 ```sh
-npm install --save sanity-plugin-documents-pane@studio-v3
+npm install --save sanity-plugin-documents-pane
 ```
 
 or
 
 ```sh
-yarn add sanity-plugin-documents-pane@studio-v3
+yarn add sanity-plugin-documents-pane
 ```
 
 This plugin is designed to be used as a [Component inside of a View](https://www.sanity.io/docs/structure-builder-reference#c0c8284844b7).


### PR DESCRIPTION
The `studio-v3` tag points at an outdated version of the plugin (and is no longer necessary anyway) - this PR removes the tag from the install instructions.