### PR TITLE
chore(deps): remove unused dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sanity-plugin-documents-pane",
-  "version": "2.1.2",
+  "version": "2.1.3-beta.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "sanity-plugin-documents-pane",
-      "version": "2.1.2",
+      "version": "2.1.3-beta.0",
       "license": "MIT",
       "dependencies": {
         "@sanity/icons": "^2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,8 +15,6 @@
         "@sanity/util": "^3.0.0",
         "@sanity/uuid": "^3.0.1",
         "dlv": "^1.1.3",
-        "react-fast-compare": "^3.2.0",
-        "rxjs": "^6.5.6",
         "sanity-plugin-utils": "^1.6.2"
       },
       "devDependencies": {
@@ -19462,7 +19460,8 @@
     "node_modules/react-fast-compare": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
-      "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ=="
+      "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==",
+      "dev": true
     },
     "node_modules/react-focus-lock": {
       "version": "2.9.1",
@@ -37464,7 +37463,8 @@
     "react-fast-compare": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
-      "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ=="
+      "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==",
+      "dev": true
     },
     "react-focus-lock": {
       "version": "2.9.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sanity-plugin-documents-pane",
-  "version": "2.1.2",
+  "version": "2.1.3-beta.0",
   "description": "Displays the results of a GROQ query in a View Pane",
   "keywords": [
     "sanity",

--- a/package.json
+++ b/package.json
@@ -59,8 +59,6 @@
     "@sanity/util": "^3.0.0",
     "@sanity/uuid": "^3.0.1",
     "dlv": "^1.1.3",
-    "react-fast-compare": "^3.2.0",
-    "rxjs": "^6.5.6",
     "sanity-plugin-utils": "^1.6.2"
   },
   "devDependencies": {


### PR DESCRIPTION
react-fast-compare and rxjs were not used in this repo, so should be safe to remove